### PR TITLE
Update to vulkano 0.12.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,8 @@ edition = "2018"
 notify = "4"
 shaderc = "0.5"
 spirv-reflect = "0.2"
-vulkano = { git = "https://github.com/mitchmindtree/vulkano", branch = "nannou_patches" }
+vulkano = "0.12"
 
 [dev-dependencies]
-vulkano = { git = "https://github.com/mitchmindtree/vulkano", branch = "nannou_patches" }
 color-backtrace = "0.1" 
 difference = "2"


### PR DESCRIPTION
If this looks good to you, would you mind merging this and publishing
the `shade_runner` crate to crates.io? I think we'll need it to be
published in order to publish nannou `0.9` (From memory, even
`dev-dependencies` require being published).