### PR TITLE
Update shaderc and vulkano deps. Publish 0.2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shade_runner"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Tom Gowan <tomrgowan@gmail.com>"]
 edition = "2018"
 description = "Allows runtime hot loading of shaders for vulkano"
@@ -12,9 +12,9 @@ keywords = ["vulkan", "vulkano", "shaders", "hotloading"]
 
 [dependencies]
 notify = "4"
-shaderc = "0.5"
+shaderc = "0.6"
 spirv-reflect = "0.2"
-vulkano = "0.13"
+vulkano = "0.14"
 
 [dev-dependencies]
 color-backtrace = "0.1" 


### PR DESCRIPTION
This patch addresses an issue with shaderc-rs 0.5.1 failing to build on
various Linux distros including Arch, Void and likely others.
google/shaderc-rs#58